### PR TITLE
Fixed Syntax Error

### DIFF
--- a/src/Rules/Length.php
+++ b/src/Rules/Length.php
@@ -14,7 +14,7 @@ class Length extends AbstractRule
     {
         list($min, $max) = explode(',', $range, 2);
 
-        $this->setRange($min, $max);
+        $this->setRange($min, (!!$max ? $max : 0));
     }
 
     public function setRange(int $min, int $max = 0)


### PR DESCRIPTION
Passing `"3,"` as a param to constructor would result in syntax error, as an empty string can't be casted to an `int`.

Found by the first stack trace of [anchorcms/anchor-cms#1183](https://github.com/anchorcms/anchor-cms/issues/1138).