### PR TITLE
Closure Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7",
+        "php": ">=7.1",
         "ext-mbstring": "*",
         "egulias/email-validator": "^2"
     },

--- a/src/Assertion.php
+++ b/src/Assertion.php
@@ -5,7 +5,7 @@ namespace Validation;
 abstract class Assertion
 {
     /**
-     * @var string
+     * @var string $message
      */
     protected $message = ':attribute is not valid';
 

--- a/src/Constraint.php
+++ b/src/Constraint.php
@@ -8,7 +8,7 @@ interface Constraint
      * Check is a value passes validation rule
      *
      * @param mixed
-     * @return boolean
+     * @return bool
      */
     public function isValid($value): bool;
 

--- a/src/Contracts/CallbackValidator.php
+++ b/src/Contracts/CallbackValidator.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+
+namespace Validation\Contracts;
+
+
+interface CallbackValidator
+{
+    public function setMessage(string $message): self;
+
+    public function getMessage(): string;
+}

--- a/src/Violations.php
+++ b/src/Violations.php
@@ -2,17 +2,19 @@
 
 namespace Validation;
 
-class Violations implements \Countable
+use Countable;
+
+class Violations implements Countable
 {
     protected $attributes = [];
 
     /**
      * Add a violation
      *
-     * @param string
-     * @param array<Constraint>
+     * @param string $attribute
+     * @param array<Constraint> $constraints
      */
-    public function add(string $attribute, array $constraints)
+    public function add(string $attribute, array $constraints): void
     {
         $this->attributes[$attribute] = $constraints;
     }
@@ -38,7 +40,7 @@ class Violations implements \Countable
         $messages = [];
 
         foreach ($this->attributes as $attribute => $constraints) {
-            $messages[$attribute] = array_map(function (Constraint $constraint) use ($attribute) {
+            $messages[$attribute] = array_map(function ($constraint) use ($attribute) {
                 return $constraint->getMessage($this->toWords($attribute));
             }, $constraints);
         }
@@ -53,7 +55,7 @@ class Violations implements \Countable
      */
     public function getMessagesLine(): string
     {
-        return array_reduce($this->getMessages(), function ($message, $messages) {
+        return array_reduce($this->getMessages(), static function ($message, $messages) {
             return $message . implode(', ', $messages);
         }, '');
     }
@@ -65,7 +67,7 @@ class Violations implements \Countable
      */
     public function count(): int
     {
-        return array_reduce($this->attributes, function ($carry, $constraints) {
+        return array_reduce($this->attributes, static function ($carry, $constraints) {
             return $carry + count($constraints);
         }, 0);
     }


### PR DESCRIPTION
Example of usage:

```php
<?php

$v = new \Validation\ArrayValidator();

$v->addConstraint('first_name', function (string $value, \Validation\Contracts\CallbackValidator $failure) {
    if (!is_string($value)) {
        return $failure->setMessage('first_name must be a string');
    }
});
```