### PR TITLE
Allow DNS validation via the 'dns' option

### DIFF
--- a/src/Assert/Email.php
+++ b/src/Assert/Email.php
@@ -3,6 +3,8 @@
 namespace Validation\Assert;
 
 use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\DNSCheckValidation;
+use Egulias\EmailValidator\Validation\MultipleValidationWithAnd;
 use Egulias\EmailValidator\Validation\RFCValidation;
 use Validation\Assertion;
 use Validation\Contracts\Constraint;
@@ -19,6 +21,16 @@ class Email extends Assertion implements Constraint
 
         $validator = new EmailValidator();
 
-        return $validator->isValid($value, new RFCValidation());
+        if ($this->dns) {
+            $validation = new MultipleValidationWithAnd([
+                new RFCValidation(),
+                new DNSCheckValidation()
+            ]);
+        } else {
+            $validation = new RFCValidation();
+        }
+        
+        return $validator->isValid($value, $validation);
     }
 }
+


### PR DESCRIPTION
Provide the ability to check if the MX record for the email domain is valid via the bool 'dns' option.