### PR TITLE
Allow Enum validation rule to accept int|string

### DIFF
--- a/src/Assert/Enum.php
+++ b/src/Assert/Enum.php
@@ -10,12 +10,12 @@ class Enum extends Assertion implements Constraint
     protected string $message;
 
     /**
-     * @var array<string>
+     * @var array<int|string, int|string>
      */
     protected array $values;
 
     /**
-     * @param array<string> $values
+     * @param array<int|string, int|string> $values
      */
     public function __construct(array $values)
     {


### PR DESCRIPTION
Due to a change with the Enum class which now returns both string or integers, this validation rule needed updating due to PHPStan errors 

Example:

```
Parameter #1 $values of class Validation\Assert\Enum constructor expects array<string>, array<string, int|string> given.  
```

